### PR TITLE
api: implement log searcher

### DIFF
--- a/api/searcher/adaptor.go
+++ b/api/searcher/adaptor.go
@@ -1,0 +1,190 @@
+package searcher
+
+import (
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type ItemType int16
+
+const (
+	TypeTiDB ItemType = iota
+	TypeTiKV
+	TypePD
+	TypeTiDBSlowQuery
+)
+
+type LevelType int16
+
+const (
+	LevelFATAL LevelType = iota
+	LevelERROR
+	LevelWARN
+	LevelINFO
+	LevelDEBUG
+)
+
+const (
+	TimeStampLayout       = "2006/01/02 15:04:05.000 -07:00"
+	FormerTimeStampLayout = "2006/01/02 15:04:05.000"
+)
+
+var (
+	TiDBLogRE = regexp.MustCompile(`^\[([^\[\]]*)\]\s\[([^\[\]]*)\]`)
+	TiKVLogRE = regexp.MustCompile(`^([^\s]*\s[^\s]*)\s([^\s]*)`)
+	PDLogRE   = regexp.MustCompile(`^([^\s]*\s[^\s]*)\s[^\s]*\s\[([^\[\]]*)\]`)
+)
+
+type TidbLogParser struct {
+	BaseParser
+}
+
+func (p *TidbLogParser) Next() (err error) {
+	defer func() {
+		if err != nil {
+			p.current = nil
+		}
+	}()
+	line, err := p.BaseParser.Next()
+	if err != nil {
+		return err
+	}
+	// TODO: TiDB version < 2.1.8, using unified log format
+	matches := TiDBLogRE.FindStringSubmatch(line)
+	if len(matches) < 3 {
+		return errors.New("failed to parser tidb log:" + line)
+	}
+	t := matches[1]
+	ts, err := parseTimeStamp(t)
+	if err != nil {
+		return err
+	}
+	level, err := parseLogLevel(matches[2])
+	if err != nil {
+		return err
+	}
+	log := p.NewLogItem(line, ts, level)
+	log.Type = TypeTiDB
+	p.current = log
+	return nil
+}
+
+type TikvLogParser struct {
+	BaseParser
+}
+
+func (p *TikvLogParser) Next() (err error) {
+	defer func() {
+		if err != nil {
+			p.current = nil
+		}
+	}()
+	line, err := p.BaseParser.Next()
+	if err != nil {
+		return err
+	}
+	// TODO: TiKV version >= 2.1.15 or >= 3.0.0, using former log format
+	matches := TiKVLogRE.FindStringSubmatch(line)
+	if len(matches) < 3 {
+		return errors.New("failed to parser tidb log:" + line)
+	}
+	ts, err := parseFormerTimeStamp(matches[1])
+	if err != nil {
+		return err
+	}
+	level, err := parseLogLevel(matches[2])
+	if err != nil {
+		return err
+	}
+	log := p.NewLogItem(line, ts, level)
+	log.Type = TypeTiKV
+	p.current = log
+	return nil
+}
+
+type PDLogParser struct {
+	BaseParser
+}
+
+func (p *PDLogParser) Next() (err error) {
+	defer func() {
+		if err != nil {
+			p.current = nil
+		}
+	}()
+	line, err := p.BaseParser.Next()
+	if err != nil {
+		return err
+	}
+	// TODO: PD will use the unified log format
+	// PD has not implemented unified log format at present (2019/07/19).
+	matches := PDLogRE.FindStringSubmatch(line)
+	if len(matches) < 3 {
+		return errors.New("failed to parser tidb log:" + line)
+	}
+	ts, err := parseFormerTimeStamp(matches[1])
+	if err != nil {
+		return err
+	}
+	level, err := parseLogLevel(matches[2])
+	if err != nil {
+		return err
+	}
+	log := p.NewLogItem(line, ts, level)
+	log.Type = TypePD
+	p.current = log
+	return nil
+}
+
+type TidbSlogQueryParser struct {
+	BaseParser
+}
+
+// TODO: implement TiDB slog query parser
+func (p *TidbSlogQueryParser) Next() error {
+	return io.EOF
+}
+
+// TiDB / TiKV / PD unified log format
+// [2019/03/04 17:04:24.614 +08:00] ...
+func parseTimeStamp(str string) (*time.Time, error) {
+	t, err := time.Parse(TimeStampLayout, str)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// TiDB / TiKV / PD log format used in former version
+// 2019/07/18 11:04:29.314 ...
+func parseFormerTimeStamp(content string) (*time.Time, error) {
+	local, err := time.LoadLocation("Asia/Chongqing")
+	if err != nil {
+		return nil, err
+	}
+	t, err := time.ParseInLocation(FormerTimeStampLayout, content, local)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+var LevelTypeMap = map[string]LevelType{
+	"FATAL": LevelFATAL,
+	"ERROR": LevelERROR,
+	"WARN":  LevelWARN,
+	"INFO":  LevelINFO,
+	"DEBUG": LevelDEBUG,
+}
+
+func parseLogLevel(s string) (LevelType, error) {
+	s = strings.ToUpper(s)
+	if level, ok := LevelTypeMap[s]; ok {
+		return level, nil
+	} else {
+		return -1, errors.New("failed to parse log level: " + s)
+	}
+}

--- a/api/searcher/adaptor_test.go
+++ b/api/searcher/adaptor_test.go
@@ -1,0 +1,149 @@
+package searcher_test
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb-foresight/searcher"
+)
+
+func TestAdaptor(t *testing.T) {
+	TestingT(t)
+}
+
+type AdaptorTestSuite struct{}
+
+var _ = Suite(&AdaptorTestSuite{})
+
+var TiDBLogExample = []string{
+	`[2019/07/19 15:15:35.846 +08:00] [INFO] [gc_worker.go:432] ["[gc worker] start redo-delete ranges"] [uuid=5aec892a9a40002] ["num of ranges"=0]`,
+	`[2019/07/19 15:15:wrong_text35.846 +08:00] [INFO] [gc_worker.go:451] ["[gc worker] finish redo-delete ranges"] [uuid=5aec892a9a40002] ["num of ranges"=0] ["cost time"=441ns]`,
+	`[2019/07/19 15:16:35.814 +08:00] [INFO] [gc_worker.go:226] ["[gc worker] there's already a gc job running, skipped"]`,
+}
+
+func (a *AdaptorTestSuite) TestTiDBParser(c *C) {
+	searchStr := "redo"
+	logStr := strings.Join(TiDBLogExample, "\n")
+	reader := bufio.NewReader(strings.NewReader(logStr))
+	parser := searcher.Tidbsearcher{
+		BaseParser: searcher.BaseParser{
+			Reader:      reader,
+			SearchBytes: []byte(searchStr),
+		},
+	}
+	t := time.Unix(1563520535, 846000000)
+	expect := &searcher.Item{
+		Time:  &t,
+		Level: searcher.LevelINFO,
+		Line:  TiDBLogExample[0],
+		Type:  searcher.TypeTiDB,
+	}
+
+	err := parser.Next()
+	c.Assert(err, IsNil)
+	item := parser.GetCurrentLog()
+	c.Assert(item, DeepEquals, expect)
+
+	err = parser.Next()
+	c.Assert(err, NotNil)
+	item = parser.GetCurrentLog()
+	c.Assert(item, IsNil)
+
+	err = parser.Next()
+	c.Assert(err, Equals, io.EOF)
+	item = parser.GetCurrentLog()
+	c.Assert(item, IsNil)
+}
+
+var TiKVLogExample = []string{
+	`2019/07/18 23:22:38.182 INFO apply.rs:910: [region 12] 13 execute admin command cmd_type: CompactLog compact_log {compact_index: 57295 compact_term: 6} at [term: 6, index: 57297]`,
+	`2019/07/18 23:43:45.481 INFO apply.rs:910: [region 12] 13 execute admin command cmd_type: CompactLog compact_log {compact_index: 57346 compact_term: 6} at [term: 6, index: 57348]`,
+	`2019/07/19 00:04:43.582 INFO apply.rs:910: [region 12] 13 execute admin command cmd_type: CompactLog compact_log {compact_index: 57397 compact_term: 6} at [term: 6, index: 57399]`,
+}
+
+func (a *AdaptorTestSuite) TestTiKVParser(c *C) {
+	searchStr := "57346"
+	logStr := strings.Join(TiKVLogExample, "\n")
+	reader := bufio.NewReader(strings.NewReader(logStr))
+	parser := searcher.Tikvsearcher{
+		BaseParser: searcher.BaseParser{
+			Reader:      reader,
+			SearchBytes: []byte(searchStr),
+		},
+	}
+	loc, err := time.LoadLocation("Asia/Chongqing")
+	c.Assert(err, IsNil)
+
+	t := time.Unix(1563464625, 481000000).In(loc)
+	expect := &searcher.Item{
+		Time:  &t,
+		Level: searcher.LevelINFO,
+		Line:  TiKVLogExample[1],
+		Type:  searcher.TypeTiKV,
+	}
+
+	err = parser.Next()
+	c.Assert(err, IsNil)
+	item := parser.GetCurrentLog()
+	c.Assert(item, DeepEquals, expect)
+
+	err = parser.Next()
+	c.Assert(err, Equals, io.EOF)
+	item = parser.GetCurrentLog()
+	c.Assert(item, IsNil)
+}
+
+var PDLogExample = []string{
+	`2019/07/19 17:04:29.375 log.go:88: [info] mvcc: [store.index: compact 489789]`,
+	`2019/07/19 17:04:29.375 log.go:86: [info] compactor: [Finished auto-compaction at revision 489789]`,
+	`2019/07/19 17:04:29.376 log.go:88: [info] mvcc: [finished scheduled compaction at 489789 (took 957.288µs)]`,
+}
+
+func (a *AdaptorTestSuite) TestParsePDParser(c *C) {
+	searchStr := "mvcc"
+	logStr := strings.Join(PDLogExample, "\n")
+	reader := bufio.NewReader(strings.NewReader(logStr))
+	parser := searcher.PDsearcher{
+		BaseParser: searcher.BaseParser{
+			Reader:      reader,
+			SearchBytes: []byte(searchStr),
+		},
+	}
+	loc, err := time.LoadLocation("Asia/Chongqing")
+	c.Assert(err, IsNil)
+
+	t := time.Unix(1563527069, 375000000).In(loc)
+	expect := &searcher.Item{
+		Time:  &t,
+		Level: searcher.LevelINFO,
+		Line:  PDLogExample[0],
+		Type:  searcher.TypePD,
+	}
+
+	err = parser.Next()
+	c.Assert(err, IsNil)
+	item := parser.GetCurrentLog()
+	c.Assert(item, DeepEquals, expect)
+
+	t = time.Unix(1563527069, 376000000).In(loc)
+	expect = &searcher.Item{
+		Time:  &t,
+		Level: searcher.LevelINFO,
+		Line:  PDLogExample[2],
+		Type:  searcher.TypePD,
+	}
+
+	err = parser.Next()
+	c.Assert(err, IsNil)
+	item = parser.GetCurrentLog()
+	c.Assert(item, DeepEquals, expect)
+
+	err = parser.Next()
+	c.Assert(err, Equals, io.EOF)
+	item = parser.GetCurrentLog()
+	c.Assert(item, IsNil)
+}

--- a/api/searcher/iterator.go
+++ b/api/searcher/iterator.go
@@ -1,0 +1,121 @@
+package searcher
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"math"
+	"path"
+	"strings"
+)
+
+type Iterator struct {
+	parsers []Parser
+}
+
+// NewIterator open all files in the root directory,
+// generate different types of log file parser and return the Iterator.
+// when call the Next function of Iterator,
+// it will return a single line log Item object parsed from all the log file.
+func NewIterator(cluster string, searchStr string) (*Iterator, error) {
+	logIterator := &Iterator{}
+	dir, err := ioutil.ReadDir(cluster)
+	if err != nil {
+		return nil, err
+	}
+	for _, fi := range dir {
+		host := fi.Name() // {host_ip}
+		if !fi.IsDir() {
+			continue
+		}
+		dirPath := path.Join(cluster, host)
+		dir, err := ioutil.ReadDir(dirPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, fi := range dir {
+			folder := fi.Name() // {component_name}-{port}
+			if !fi.IsDir() {
+				continue
+			}
+			dirPath := path.Join(dirPath, folder)
+			dir, err := ioutil.ReadDir(dirPath)
+			if err != nil {
+				return nil, err
+			}
+			for _, fi := range dir {
+				filename := fi.Name()
+				if fi.IsDir() {
+					continue
+				}
+				parser, err := NewParser(cluster, host, folder, filename, searchStr)
+				if err != nil {
+					if err == io.EOF {
+						continue
+					}
+					return nil, err
+				}
+				logIterator.AddParser(parser)
+			}
+		}
+	}
+	return logIterator, nil
+}
+
+func parseFolder(name string) (string, string, error) {
+	s := strings.Split(name, "-")
+	if len(s) < 2 {
+		return "", "", errors.New("wrong folder name: " + name)
+	}
+	return s[0], s[1], nil
+}
+
+func (l *Iterator) Next() (*Item, error) {
+	if len(l.parsers) == 0 {
+		return nil, errors.New("empty log dir")
+	}
+	var res *Item
+	currentTs := int64(math.MaxInt64)
+	for _, parser := range l.parsers {
+		// choose the log with earlier timestamp
+		log := parser.GetCurrentLog()
+		ts := parser.GetTs()
+		if ts < currentTs {
+			res = log
+			currentTs = ts
+			err := parser.Next()
+			if err != nil {
+				if err == io.EOF {
+					continue
+				}
+				return nil, err
+			}
+		}
+	}
+	return res, nil
+}
+
+func (l *Iterator) Close() error {
+	for _, parser := range l.parsers {
+		err := parser.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Iterator) AddParser(parser Parser) {
+	if l.parsers == nil {
+		l.parsers = []Parser{parser}
+	} else {
+		l.parsers = append(l.parsers, parser)
+	}
+}
+
+// SearchLog open all log files in the directory,
+// analyze each log in each file by merge sort (from old to new by timestamp),
+// return the constructed LogIter object and provide the Next function for external call.
+func SearchLog(dir string, text string) (*Iterator, error) {
+	return NewIterator(dir, text)
+}

--- a/api/searcher/parser.go
+++ b/api/searcher/parser.go
@@ -1,0 +1,135 @@
+package searcher
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"math"
+	"os"
+	"path"
+	"time"
+)
+
+type Entry struct {
+	Type  string // golang type of Value
+	Value interface{}
+}
+
+type Item struct {
+	File      string           // name of log file
+	Time      *time.Time       // timestamp of a single line log
+	Level     LevelType        // log level
+	Host      string           // host ip
+	Port      string           // port of component
+	Component string           // name of component
+	Line      string           // content of a single line log
+	Type      ItemType         // type of log file
+	Entries   map[string]Entry // field parsed from the log
+}
+
+type Parser interface {
+	Next() error  // parse next log, assign it to currentLog
+	Close() error // close file descriptor
+	GetTs() int64 // get timestamp of currentLog
+	GetCurrentLog() *Item
+}
+
+type BaseParser struct {
+	Filename    string
+	Host        string
+	Port        string
+	Component   string
+	File        *os.File
+	Reader      *bufio.Reader
+	SearchBytes []byte
+	current     *Item
+}
+
+func (p *BaseParser) NewLogItem(line string, ts *time.Time, level LevelType) *Item {
+	return &Item{
+		File:      p.Filename,
+		Time:      ts,
+		Level:     level,
+		Host:      p.Host,
+		Port:      p.Port,
+		Component: p.Component,
+		Line:      line,
+	}
+}
+
+func (p *BaseParser) Next() (string, error) {
+	var line []byte
+	var err error
+	for {
+		// Note: Only the first 4094 byte of this row can be read out
+		line, _, err = p.Reader.ReadLine()
+		if err != nil {
+			return "", err
+		}
+		if bytes.Contains(line, p.SearchBytes) {
+			break
+		}
+	}
+	return string(line), nil
+}
+
+func (p *BaseParser) GetTs() int64 {
+	if p.current.Time == nil {
+		return math.MaxInt64
+	}
+	return p.current.Time.Unix()
+}
+
+func (p *BaseParser) GetCurrentLog() *Item {
+	return p.current
+}
+
+func (p *BaseParser) Close() error {
+	if p.File == nil {
+		return errors.New("close a file which does not open")
+	}
+	return p.File.Close()
+}
+
+// NewParser return a Parser for specific log type
+func NewParser(cluster, host, folder, filename, searchStr string) (Parser, error) {
+	component, port, err := parseFolder(folder)
+	if err != nil {
+		return nil, err
+	}
+	filePath := path.Join(cluster, host, folder, filename)
+	f, err := os.OpenFile(filePath, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(f)
+	base := BaseParser{
+		Filename:    filename,
+		Host:        host,
+		Component:   component,
+		Port:        port,
+		File:        f,
+		Reader:      reader,
+		SearchBytes: []byte(searchStr),
+	}
+	var parser Parser
+	switch component {
+	case "tidb":
+		if filename == "tidb_slow_query.log" {
+			parser = &TidbSlogQueryParser{base}
+		} else {
+			parser = &TidbLogParser{base}
+		}
+	case "tikv":
+		parser = &TikvLogParser{base}
+	case "pd":
+		parser = &PDLogParser{base}
+	default:
+		return nil, errors.New("newParser: unsupported component type")
+	}
+	err = parser.Next()
+	if err != nil {
+		return nil, err
+	}
+	return parser, nil
+}

--- a/api/searcher/searcher.go
+++ b/api/searcher/searcher.go
@@ -2,11 +2,10 @@ package searcher
 
 import (
 	"errors"
-	"fmt"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Searcher struct {
@@ -14,18 +13,18 @@ type Searcher struct {
 	l sync.Mutex
 }
 
-type Log struct {
-	Ip        string    `json:"ip"`
-	Port      string    `json:"port"`
-	File      string    `json:"file"`
-	Time      time.Time `json:"time"`
-	Component string    `json:"component"`
-	Level     string    `json:"level"`
-	Content   string    `json:"content"`
-}
+//type Log struct {
+//	Ip        string    `json:"ip"`
+//	Port      string    `json:"port"`
+//	File      string    `json:"file"`
+//	Time      time.Time `json:"time"`
+//	Component string    `json:"component"`
+//	Level     string    `json:"level"`
+//	Content   string    `json:"content"`
+//}
 
 type LogIter interface {
-	Next() (*Log, error)
+	Next() (*Item, error)
 	Close() error
 }
 
@@ -42,7 +41,7 @@ func NewIter(iter LogIter) *IterWithAccessTime {
 	}
 }
 
-func (i *IterWithAccessTime) Next() (*Log, error) {
+func (i *IterWithAccessTime) Next() (*Item, error) {
 	i.l.Lock()
 	defer i.l.Unlock()
 	i.access = time.Now()
@@ -128,49 +127,7 @@ func (s *Searcher) Search(dir string, text string, token string) (LogIter, strin
 	}
 }
 
-// below is mock
-type Mock struct {
-	dir   string
-	text  string
-	size  int
-	count int
-}
 
-func NewMock(dir string, text string) *Mock {
-	return &Mock{
-		dir:  dir,
-		text: text,
-		size: 100,
-	}
-}
-
-func (m *Mock) Next() (*Log, error) {
-	log.Info("count: ", m.count, " size: ", m.size)
-	if m.count == m.size {
-		return nil, nil
-	}
-	m.count++
-
-	return &Log{
-		Ip:        "1.1.1.1",
-		Port:      "1024",
-		File:      "test.log",
-		Time:      time.Now(),
-		Component: "tikv",
-		Level:     "INFO",
-		Content:   fmt.Sprintf("在%s目录搜素%s的第%d条结果", m.dir, m.text, m.count),
-	}, nil
-}
-
-func (*Mock) Close() error {
-	log.Info("mock close")
-	return nil
-}
-
-func SearchLog(dir string, text string) (LogIter, error) {
-	return NewMock(dir, text), nil
-}
-
-func GetIterFromToken(token string) LogIter {
-	return &Mock{}
-}
+//func GetIterFromToken(token string) LogIter {
+//	return &Mock{}
+//}

--- a/api/server/log.go
+++ b/api/server/log.go
@@ -13,7 +13,7 @@ import (
 
 type LogResult struct {
 	Token string          `json:"token"`
-	Logs  []*searcher.Log `json:"logs"`
+	Logs  []*searcher.Item `json:"logs"`
 }
 
 func (s *Server) listLogs() ([]string, error) {
@@ -47,7 +47,7 @@ func (s *Server) searchLog(r *http.Request) (*LogResult, error) {
 		return nil, utils.NewForesightError(http.StatusNotFound, "NOT_FOUND", "token not found")
 	}
 
-	logs := []*searcher.Log{}
+	logs := []*searcher.Item{}
 	for i := 0; i < int(limit); i++ {
 		if l, err := iter.Next(); err != nil {
 			log.Error("search log: ", err)


### PR DESCRIPTION
## Purpose
This PR has completed the functions of the `log search` module:

## Description
Calling `NewIterator()` will parse the log directory synchronized to the local, search the provided keywords, and return an `Iterator`.
Each time `Iterator.Next()` function is called, it will return the queried single-line log information in the order of log timestamp.

## Note
At present, these are TODOs as follows:
- parser for `tidb_slow_query.log`
- choose different `LogParser` according to TiDB/TiKV/PD version
- unit test for `iterator.go` and `parser.go`