### PR TITLE
bugfix/slowlog report

### DIFF
--- a/api/model/report/report.go
+++ b/api/model/report/report.go
@@ -17,7 +17,7 @@ type Report struct {
 	DBInfo       interface{} `json:"dbinfo,omitempty"`
 	AlertInfo    interface{} `json:"alert,omitempty"`
 	ResourceInfo interface{} `json:"resource,omitempty"`
-	SlowLogInfo  interface{} `json:"slowlog,omitempty"`
+	SlowLogInfo  interface{} `json:"slow_log,omitempty"`
 	HardwareInfo interface{} `json:"hardware,omitempty"`
 	SoftwareInfo interface{} `json:"software_version,omitempty"`
 	ConfigInfo   interface{} `json:"software_config,omitempty"`

--- a/api/model/report/slowlog.go
+++ b/api/model/report/slowlog.go
@@ -17,7 +17,7 @@ func (r *Report) loadSlowLogInfo() error {
 	}
 
 	rows, err := r.db.Query(
-		`SELECT MAX(time), query, COUNT(time) as c FROM inspection_slow_log WHERE inspection = ? GROUP BY query ORDER BY c LIMIT 0, 20`,
+		`SELECT time, query, COUNT(time) as c FROM inspection_slow_log WHERE inspection = ? GROUP BY query ORDER BY c LIMIT 0, 20`,
 		r.inspectionId,
 	)
 	if err != nil {


### PR DESCRIPTION
The database/sql will treat result of MAX(time) as []unint8 instead
of time.Time, which cause sql error.