### PR TITLE
Fix/tf 50

### DIFF
--- a/collector/groups.py
+++ b/collector/groups.py
@@ -284,7 +284,14 @@ def setup_alert_ops(addr='127.0.0.1:9090', basedir='alert'):
 
 def setup_db_ops(addr='127.0.0.1:10080', basedir='dbinfo'):
     ops = []
-    dbs = get_databases(addr)
+    try:
+        dbs = get_databases(addr)
+    except Exception as e:
+        logging.error('get database failed, error:%s', e)
+        def f(): raise e
+        # return an Op with an exception, when it is executed
+        # the execption will be raised and recored by status.json
+        return [Op(None, None, f)]
     join = os.path.join
 
     def op(name):


### PR DESCRIPTION
在采集开始前，collector 会先拿一些前置信息，比如数据库名字和metric名字。

如果集群关掉，在进入到采集之前，程序就会异常退出，这显然不符合预期，因为其他信息比如basic，slowlog 原则上都可以继续采集。

因此，遇到这种情况，将异常捕获，当真正执行dbinfo和 metric 收集时再重新抛出来。这么做可以不影响其他信息的收集，异常信息也能记录到status.json