### PR TITLE
Bugfix: set duration on influxdb database to remove expired data

### DIFF
--- a/analyzer/output/metric/save.go
+++ b/analyzer/output/metric/save.go
@@ -104,7 +104,7 @@ func (t *saveMetricTask) initInfluxdbClient() (influxdb.Client, error) {
 		return nil, err
 	}
 
-	resp, err := cli.Query(influxdb.NewQuery("CREATE database "+INFLUX_DB, "", ""))
+	resp, err := cli.Query(influxdb.NewQuery(fmt.Sprintf("CREATE DATABASE %s WITH DURATION 30d", INFLUX_DB), "", ""))
 	if err != nil {
 		cli.Close()
 		return nil, err


### PR DESCRIPTION
With statement create database xxx with duration xxx, the influxdb
can remove the expired data automaticlly. By this we can get rid
of the problem that influxdb refuse data.

Signed-off-by: lucklove <gnu.crazier@gmail.com>