### PR TITLE
collector: use absolute timestamp in cluster.json

### DIFF
--- a/collector/collect.go
+++ b/collector/collect.go
@@ -128,14 +128,16 @@ func (m *Manager) CollectClusterInfo(
 	var start time.Time
 	if offset, err := strconv.Atoi(opt.ScrapeBegin); err == nil && offset < 0 {
 		start = end.Add(time.Hour * time.Duration(offset))
-		// update time string in setting to ensure all collectors work properly
-		opt.ScrapeBegin = start.Format(time.RFC3339)
 	} else {
 		start, err = utils.ParseTime(opt.ScrapeBegin)
 		if err != nil {
 			return err
 		}
 	}
+
+	// update time strings in setting to ensure all collectors work properly
+	opt.ScrapeBegin = start.Format(time.RFC3339)
+	opt.ScrapeEnd = end.Format(time.RFC3339)
 
 	resultDir, err := m.getOutputDir(cOpt.Dir)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Use absolute timestamps in `cluster-json`, so that server can correctly handle them.
