### PR TITLE
collector: increase default scp speed

### DIFF
--- a/cmd/diag/command/collect.go
+++ b/cmd/diag/command/collect.go
@@ -95,7 +95,7 @@ func newCollectCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&cOpt.MetricsFilter, "metricsfilter", nil, "prefix of metrics to collect")
 	cmd.Flags().StringVar(&metricsConf, "metricsconfig", "", "config file of metricsfilter")
 	cmd.Flags().StringVarP(&cOpt.Dir, "output", "o", "", "output directory of collected data")
-	cmd.Flags().IntVarP(&cOpt.Limit, "limit", "l", 10000, "Limits the used bandwidth, specified in Kbit/s")
+	cmd.Flags().IntVarP(&cOpt.Limit, "limit", "l", 100000, "Limits the used bandwidth, specified in Kbit/s")
 	cmd.Flags().Uint64Var(&gOpt.APITimeout, "api-timeout", 10, "Timeout in seconds when querying PD APIs.")
 	cmd.Flags().BoolVar(&cOpt.CompressMetrics, "compress-metrics", true, "Compress collected metrics data.")
 	cmd.Flags().BoolVar(&cOpt.CompressScp, "compress-scp", true, "Compress when transfer config and logs.")


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- default scp speed is too low

### What is changed and how it works?

when both enable compress and increase limit from 10000 to 100000, the network usage is not increase (almost 1M/s).

![Screenshot from 2021-11-22 16-55-10](https://user-images.githubusercontent.com/20392070/142990149-7b42dcc0-4345-4074-9e23-71663e1072ef.png)
![Screenshot from 2021-11-22 17-11-13](https://user-images.githubusercontent.com/20392070/142990166-59970fac-97c2-492c-9a0d-c27f94f532e0.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

