### PR TITLE
checker: use nightly when version is not a semantic version

### DIFF
--- a/checker/proto/data.go
+++ b/checker/proto/data.go
@@ -326,6 +326,7 @@ type NodeData struct {
 	Configs    []Config
 	DeviceData DeviceData
 }
+
 type Config interface {
 	GetComponent() string
 	GetPort() int
@@ -383,9 +384,10 @@ func (vr VersionRange) Contain(target string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// if the given version can not be parsed, return false without error
 	ver, err := semver.NewVersion(target)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	return verCheck.Check(ver), nil
 }

--- a/checker/proto/data_test.go
+++ b/checker/proto/data_test.go
@@ -46,6 +46,12 @@ func TestVersionRange_IsTarget(t *testing.T) {
 		{Target: "v5.0.3", VRange: VersionRange(">=v4.0.0,<v4.0.15||v5.0.0||v5.0.1||v5.0.2||v5.0.3||v5.1.0||v5.1.1||v5.2.0||v5.2.1"), Expected: true},
 		{Target: "v4.0.15", VRange: VersionRange(">=v4.0.0,<v4.0.15||v5.0.0||v5.0.1||v5.0.2||v5.0.3||v5.1.0||v5.1.1||v5.2.0||v5.2.1"), Expected: false},
 		{Target: "v5.3.0", VRange: VersionRange(">=v4.0.0,<v4.0.15||v5.0.0||v5.0.1||v5.0.2||v5.0.3||v5.1.0||v5.1.1||v5.2.0||v5.2.1"), Expected: false},
+		{Target: "latest", VRange: VersionRange(""), Expected: true},
+		{Target: "latest", VRange: VersionRange(">=v4.0.0"), Expected: false},
+		{Target: "nightly", VRange: VersionRange(""), Expected: true},
+		{Target: "nightly", VRange: VersionRange(">=v4.0.0"), Expected: false},
+		{Target: "xxxxx", VRange: VersionRange(""), Expected: true},          // invalid version
+		{Target: "xxxxx", VRange: VersionRange(">=v4.0.0"), Expected: false}, // invalid version
 	}
 	for _, tc := range tt {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Shenjun <mashenjun0902@gmail.com>

<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

close #250 

### What is changed and how it works?

- change `VersionRange.Contain()` to filter on none semantic version
- change `FileFetcher.getClusterVersion()` to infer none semantic version 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes
