### PR TITLE
collector: always compress metrics

### DIFF
--- a/cmd/diag/command/collect.go
+++ b/cmd/diag/command/collect.go
@@ -113,7 +113,6 @@ func newCollectCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&cOpt.Dir, "output", "o", "", "output directory of collected data")
 	cmd.Flags().IntVarP(&cOpt.Limit, "limit", "l", -1, "Limits the used bandwidth, specified in Kbit/s")
 	cmd.Flags().Uint64Var(&gOpt.APITimeout, "api-timeout", 10, "Timeout in seconds when querying PD APIs.")
-	cmd.Flags().BoolVar(&cOpt.CompressMetrics, "compress-metrics", true, "Compress collected metrics data.")
 	cmd.Flags().BoolVar(&cOpt.CompressScp, "compress-scp", true, "Compress when transfer config and logs.Only works with system ssh")
 	cmd.Flags().BoolVar(&cOpt.ExitOnError, "exit-on-error", false, "Stop collecting and exit if an error occurs.")
 

--- a/cmd/diag/command/collectdm.go
+++ b/cmd/diag/command/collectdm.go
@@ -114,7 +114,6 @@ func newCollectDMCmd() *cobra.Command {
 	cmd.Flags().StringVar(&metricsConf, "metricsconfig", "", "config file of metricsfilter")
 	cmd.Flags().StringVarP(&cOpt.Dir, "output", "o", "", "output directory of collected data")
 	cmd.Flags().IntVarP(&cOpt.Limit, "limit", "l", -1, "Limits the used bandwidth, specified in Kbit/s")
-	cmd.Flags().BoolVar(&cOpt.CompressMetrics, "compress-metrics", true, "Compress collected metrics data.")
 	cmd.Flags().BoolVar(&cOpt.CompressScp, "compress-scp", true, "Compress when transfer config and logs.Only works with system ssh")
 	cmd.Flags().BoolVar(&cOpt.ExitOnError, "exit-on-error", false, "Stop collecting and exit if an error occurs.")
 

--- a/collector/collect.go
+++ b/collector/collect.go
@@ -76,15 +76,14 @@ type BaseOptions struct {
 
 // CollectOptions contains the options defining which type of data to collect
 type CollectOptions struct {
-	Mode            string // the cluster is deployed with what type of tool
-	Include         set.StringSet
-	Exclude         set.StringSet
-	MetricsFilter   []string
-	Dir             string // target directory to store collected data
-	Limit           int    // rate limit of SCP
-	CompressMetrics bool   // compress of files during collecting
-	CompressScp     bool   // compress of files during collecting
-	ExitOnError     bool   // break the process and exit when an error occurs
+	Mode          string // the cluster is deployed with what type of tool
+	Include       set.StringSet
+	Exclude       set.StringSet
+	MetricsFilter []string
+	Dir           string // target directory to store collected data
+	Limit         int    // rate limit of SCP
+	CompressScp   bool   // compress of files during collecting
+	ExitOnError   bool   // break the process and exit when an error occurs
 }
 
 // CollectStat is estimated size stats of data to be collected
@@ -169,13 +168,11 @@ func (m *Manager) CollectClusterInfo(
 				BaseOptions: opt,
 				opt:         gOpt,
 				resultDir:   resultDir,
-				compress:    cOpt.CompressMetrics,
 			},
 			&MetricCollectOptions{ // metrics
 				BaseOptions: opt,
 				opt:         gOpt,
 				resultDir:   resultDir,
-				compress:    cOpt.CompressMetrics,
 				filter:      cOpt.MetricsFilter,
 			},
 		)


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Always compress metrics JSONs collected, so there's no need to keep the switch anymore.
