### PR TITLE
Enable gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
       # - errcheck
       # - staticcheck
     - stylecheck
-      # - gosec
+    - gosec
     - asciicheck
     - bodyclose
       # - exportloopref

--- a/collector/config.go
+++ b/collector/config.go
@@ -436,7 +436,7 @@ func buildRealtimeConfigCollectingTasks(ctx context.Context, inst models.Compone
 					err = os.WriteFile(
 						filepath.Join(resultDir, host, instDir, "conf", config.filename),
 						resp,
-						0644,
+						0600,
 					)
 					if err != nil {
 						return err

--- a/collector/k8s.go
+++ b/collector/k8s.go
@@ -152,7 +152,7 @@ func buildTopoForK8sCluster(
 		status := tc.Status.Conditions[0].Type
 		klog.Infof("found cluster '%s': %s, %s, created at %s",
 			clsName, tc.Spec.Version, status, cTime)
-		cluster = &tc
+		cluster = &tc //#nosec G601
 		cls.Version = tc.Spec.Version
 
 		for _, ins := range tc.Status.PD.Members {

--- a/collector/rebuild.go
+++ b/collector/rebuild.go
@@ -421,7 +421,7 @@ func (i *influxdb) start(ctx context.Context) error {
 
 func (i *influxdb) ready() bool {
 	url := fmt.Sprintf("http://%s:%d/health", i.Host, i.HTTPPort)
-	body, err := utils.NewHTTPClient(time.Second*2, &tls.Config{}).Get(context.TODO(), url)
+	body, err := utils.NewHTTPClient(time.Second*2, &tls.Config{MinVersion: tls.VersionTLS12}).Get(context.TODO(), url)
 	if err != nil {
 		//fmt.Println("still waiting for influxdb to start...")
 		return false
@@ -714,7 +714,7 @@ http_port = %d
 	custom := fmt.Sprintf(tpl, g.Host, g.Port)
 	customFName := filepath.Join(g.DataDir, "conf", "custom.ini")
 
-	err = os.WriteFile(customFName, []byte(custom), 0644)
+	err = os.WriteFile(customFName, []byte(custom), 0600)
 	if err != nil {
 		return nil, errors.AddStack(err)
 	}
@@ -747,7 +747,7 @@ datasources:
 `
 
 	s := fmt.Sprintf(tpl, clusterName, clusterName, promURL)
-	err = os.WriteFile(fname, []byte(s), 0644)
+	err = os.WriteFile(fname, []byte(s), 0600)
 	if err != nil {
 		return errors.AddStack(err)
 	}
@@ -782,7 +782,7 @@ func replaceDatasource(dashboardDir string, datasourceName string) error {
 		s = strings.ReplaceAll(s, "${DS_LIGHTNING}", datasourceName)
 		s = re.ReplaceAllLiteralString(s, datasourceName)
 
-		return os.WriteFile(path, []byte(s), 0644)
+		return os.WriteFile(path, []byte(s), 0600)
 	})
 
 	if err != nil {
@@ -811,7 +811,7 @@ providers:
 `
 	s := fmt.Sprintf(tpl, clusterName, clusterName, dir)
 
-	err = os.WriteFile(fname, []byte(s), 0644)
+	err = os.WriteFile(fname, []byte(s), 0600)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/pkg/packager/history.go
+++ b/pkg/packager/history.go
@@ -51,7 +51,7 @@ func (h *Histroy) Store() error {
 	if len(list) > 10 {
 		list = list[:10]
 	}
-	return os.WriteFile(h.file, []byte(strings.Join(list, "\n")), 0664)
+	return os.WriteFile(h.file, []byte(strings.Join(list, "\n")), 0600)
 }
 
 func (h *Histroy) PrintList() {

--- a/pkg/packager/upload.go
+++ b/pkg/packager/upload.go
@@ -335,7 +335,7 @@ func InitClient(Endpoint string) *http.Client {
 		}
 		return &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{RootCAs: roots},
+				TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
 			},
 		}
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

- Enables `gosec` as part of `golangci-lint`
- Tries to fix any issues found by gosec, mostly file permissions and TLS version config.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

