### PR TITLE
add basic funcs to set custom log and config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ images: k8s
 	docker build --tag "${DOCKER_REPO}/diag:${IMAGE_TAG}" -f k8s/images/diag/Dockerfile k8s/images/diag
 
 test:
-	$(GO) test ./...
+	$(GO) test -cover ./...
 
 check: fmt vet lint check-static
 

--- a/pkg/models/metadata.go
+++ b/pkg/models/metadata.go
@@ -1,0 +1,59 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"github.com/pingcap/tiup/pkg/set"
+)
+
+// Some predefined key names for extended metadata
+const (
+	AttrKeyConfigFileList = "config_files"
+	AttrKeyLogFileList    = "log_files"
+	AttrKeyMetricsDir     = "metrics_dir"
+)
+
+// AttributeMap are extended key-values related to an object
+type AttributeMap map[string]interface{}
+
+// AddConfigFile inserts path of a config file to the list
+func (attr AttributeMap) AddConfigFile(p string) {
+	var tmp []string
+	if m, ok := attr[AttrKeyConfigFileList]; ok {
+		tmp = m.([]string)
+	} else {
+		tmp = make([]string, 0)
+	}
+	s := set.NewStringSet(tmp...)
+	s.Insert(p)
+	attr[AttrKeyConfigFileList] = s.Slice()
+}
+
+// AddLogFile inserts path of a log file to the list
+func (attr AttributeMap) AddLogFile(p string) {
+	var tmp []string
+	if m, ok := attr[AttrKeyLogFileList]; ok {
+		tmp = m.([]string)
+	} else {
+		tmp = make([]string, 0)
+	}
+	s := set.NewStringSet(tmp...)
+	s.Insert(p)
+	attr[AttrKeyLogFileList] = s.Slice()
+}
+
+// SetMetricsDir sets the path of metrics files
+func (attr AttributeMap) SetMetricsDir(p string) {
+	attr[AttrKeyMetricsDir] = p
+}

--- a/pkg/models/metadata_test.go
+++ b/pkg/models/metadata_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestAttributesMap(t *testing.T) {
+	attr1 := AttributeMap{}
+	attr1["foo"] = "bar"
+	attr1.AddConfigFile("/path/to/1.conf")
+	attr1.AddConfigFile("rel/path/to/2.conf")
+	attr1.AddLogFile("1.log")
+	attr1.AddLogFile("path/to/2.log")
+	attr1.SetMetricsDir("some/metrics")
+	sort.Strings(attr1[AttrKeyConfigFileList].([]string))
+	sort.Strings(attr1[AttrKeyLogFileList].([]string))
+
+	attr2 := AttributeMap{}
+	attr2["foo"] = "bar"
+	attr2[AttrKeyConfigFileList] = []string{
+		"/path/to/1.conf",
+		"rel/path/to/2.conf",
+	}
+	attr2[AttrKeyLogFileList] = []string{
+		"1.log",
+		"path/to/2.log",
+	}
+	sort.Strings(attr2[AttrKeyConfigFileList].([]string))
+	sort.Strings(attr2[AttrKeyLogFileList].([]string))
+	attr2[AttrKeyMetricsDir] = "some/metrics"
+
+	if !reflect.DeepEqual(attr1, attr2) {
+		t.Errorf("attributes mismatch:\n  added by func: %s\n  added by hand: %s\n", attr1, attr2)
+	}
+}

--- a/pkg/models/tidbcluster.go
+++ b/pkg/models/tidbcluster.go
@@ -20,9 +20,6 @@ import (
 	"github.com/pingcap/tiup/pkg/set"
 )
 
-// AttributeMap are extended key-values related to an object
-type AttributeMap map[string]interface{}
-
 // ComponentType are types of a component
 type ComponentType string
 


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add `AddConfigFile()`, `AddLogFile()` and `SetMetricsDir()` functions to help users set pre-defined metadata fields easily.

### What is changed and how it works?
Use pre-defined key names to set certain fields.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
