### PR TITLE
collectors: fix collect perf info can't run in k8s

### DIFF
--- a/collector/collect.go
+++ b/collector/collect.go
@@ -277,12 +277,13 @@ func (m *Manager) CollectClusterInfo(
 	}
 
 	if canCollect(cOpt, CollectTypePerf) {
-		if m.mode == CollectModeK8s {
-			cOpt.PerfDuration = 30
-		}
-
 		if cOpt.PerfDuration < 1 {
-			return "", errors.Errorf("perf-duration cannot be less than 1")
+			if m.mode == CollectModeK8s {
+				cOpt.PerfDuration = 30
+			} else {
+				return "", errors.Errorf("perf-duration cannot be less than 1")
+			}
+
 		}
 		collectors = append(collectors,
 			&PerfCollectOptions{


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
collectors: fix collect perf info can't run in k8s

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

