### PR TITLE
diag: dump metrics from manual deployed tidb cluster

### DIFF
--- a/cmd/diag/command/config.go
+++ b/cmd/diag/command/config.go
@@ -38,7 +38,7 @@ func newConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config <key> <value>",
 		Short: "set an individual value in diag configuration file",
-		Long:  `set an individual value in diag configuration file, like
+		Long: `set an individual value in diag configuration file, like
   "diag config clinic.token xxxxxxxxxx"
 if not specify key nor value, an interactive interface will be used to set necessary configuration`,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/diag/command/root.go
+++ b/cmd/diag/command/root.go
@@ -148,6 +148,7 @@ func init() {
 		newCheckCmd(),
 		newAuditCmd(),
 		newConfigCmd(),
+		newUtilCmd(),
 	)
 }
 

--- a/cmd/diag/command/util.go
+++ b/cmd/diag/command/util.go
@@ -1,0 +1,38 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newUtilCmd() *cobra.Command {
+	utilCmd := &cobra.Command{
+		Use:    "util <command>",
+		Short:  "Some useful utilities for manual collecting and diagnostics.",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			return nil
+		},
+	}
+
+	utilCmd.AddCommand(
+		newMetricDumpCmd(),
+	)
+
+	return utilCmd
+}

--- a/cmd/diag/command/util_metricdump.go
+++ b/cmd/diag/command/util_metricdump.go
@@ -1,0 +1,115 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pingcap/diag/collector"
+	"github.com/pingcap/diag/pkg/telemetry"
+	"github.com/pingcap/diag/pkg/utils"
+	"github.com/pingcap/tiup/pkg/cluster/spec"
+	"github.com/pingcap/tiup/pkg/set"
+	"github.com/spf13/cobra"
+)
+
+func newMetricDumpCmd() *cobra.Command {
+	opt := collector.BaseOptions{}
+	cOpt := collector.CollectOptions{
+		Include: set.NewStringSet(collector.CollectTypeMonitor),
+		Exclude: set.NewStringSet(),
+	}
+	var (
+		clsName      string
+		promEndpoint string
+		pdEndpoint   string
+		metricsConf  string
+		caPath       string
+		certPath     string
+		keyPath      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "metricdump",
+		Short: "Dump metrics from a Prometheus endpoint.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.SetDisplayModeFromString(gOpt.DisplayMode)
+			spec.Initialize("cluster")
+			tidbSpec := spec.GetSpecManager()
+			cm := collector.NewManager("tidb", tidbSpec, log)
+
+			opt.Cluster = clsName
+			cOpt.RawRequest = strings.Join(os.Args[1:], " ")
+			cOpt.Mode = collector.CollectModeManual      // set collect mode
+			cOpt.ExtendedAttrs = make(map[string]string) // init attributes map
+			cOpt.ExtendedAttrs[collector.AttrKeyPDEndpoint] = pdEndpoint
+			cOpt.ExtendedAttrs[collector.AttrKeyPromEndpoint] = promEndpoint
+			cOpt.ExtendedAttrs[collector.AttrKeyTLSCAFile] = caPath
+			cOpt.ExtendedAttrs[collector.AttrKeyTLSCertFile] = certPath
+			cOpt.ExtendedAttrs[collector.AttrKeyTLSKeyFile] = keyPath
+
+			if metricsConf != "" {
+				f, err := os.Open(metricsConf)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				s := bufio.NewScanner(f)
+				for s.Scan() {
+					if len(s.Text()) > 0 {
+						cOpt.MetricsFilter = append(cOpt.MetricsFilter, s.Text())
+					}
+				}
+			}
+
+			_, err := cm.CollectClusterInfo(&opt, &cOpt, &gOpt, nil, nil, skipConfirm)
+			// time is validated and updated during the collecting process
+			if reportEnabled {
+				st, errs := utils.ParseTime(opt.ScrapeBegin)
+				et, erre := utils.ParseTime(opt.ScrapeEnd)
+				if errs == nil && erre == nil {
+					teleReport.CommandInfo.(*telemetry.CollectInfo).
+						TimeSpan = int64(et.Sub(st))
+				}
+
+				if size, err := utils.DirSize(cOpt.Dir); err == nil {
+					teleReport.CommandInfo.(*telemetry.CollectInfo).
+						DataSize = size
+				}
+			}
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&clsName, "name", "", "name of the TiDB cluster")
+	cmd.Flags().StringVar(&promEndpoint, "prometheus", "", "Prometheus endpoint")
+	cmd.Flags().StringVar(&pdEndpoint, "pd", "", "PD endpoint of the TiDB cluster")
+	cmd.Flags().StringVar(&caPath, "ca-file", "", "path to the CA of TLS enabled cluster")
+	cmd.Flags().StringVar(&certPath, "cert-file", "", "path to the client certification of TLS enabled cluster")
+	cmd.Flags().StringVar(&keyPath, "key-file", "", "path to the private key of client certification of TLS enabled cluster")
+	cmd.Flags().StringVarP(&opt.ScrapeBegin, "from", "f", time.Now().Add(time.Hour*-2).Format(time.RFC3339), "start timepoint when collecting timeseries data")
+	cmd.Flags().StringVarP(&opt.ScrapeEnd, "to", "t", time.Now().Format(time.RFC3339), "stop timepoint when collecting timeseries data")
+	cmd.Flags().StringSliceVar(&cOpt.MetricsFilter, "metricsfilter", nil, "prefix of metrics to collect")
+	cmd.Flags().StringVar(&metricsConf, "metricsconfig", "", "config file of metricsfilter")
+	cmd.Flags().StringVarP(&cOpt.Dir, "output", "o", "", "output directory of collected data")
+
+	cobra.MarkFlagRequired(cmd.Flags(), "name")
+	cobra.MarkFlagRequired(cmd.Flags(), "prometheus")
+	cobra.MarkFlagRequired(cmd.Flags(), "pd")
+
+	return cmd
+}

--- a/collector/collect.go
+++ b/collector/collect.go
@@ -51,9 +51,15 @@ const (
 	CollectTypeComponentMeta = "component_meta"
 	CollectTypeBind          = "sql_bind"
 
-	CollectModeTiUP = "tiup-cluster"  // collect from a tiup-cluster deployed cluster
-	CollectModeK8s  = "tidb-operator" // collect from a tidb-operator deployed cluster
+	CollectModeTiUP   = "tiup-cluster"  // collect from a tiup-cluster deployed cluster
+	CollectModeK8s    = "tidb-operator" // collect from a tidb-operator deployed cluster
+	CollectModeManual = "manual"        // collect from a manually deployed cluster
 
+	AttrKeyPromEndpoint = "prometheus-endpoint"
+	AttrKeyPDEndpoint   = "pd-endpoint"
+	AttrKeyTLSCAFile    = "tls-ca-file"
+	AttrKeyTLSCertFile  = "tls-cert-file"
+	AttrKeyTLSKeyFile   = "tls-privkey-file"
 )
 
 var CollectDefaultSet = set.NewStringSet(
@@ -98,17 +104,18 @@ type BaseOptions struct {
 
 // CollectOptions contains the options defining which type of data to collect
 type CollectOptions struct {
-	RawRequest    interface{}   // raw collect command or request
-	Mode          string        // the cluster is deployed with what type of tool
-	ProfileName   string        // the name of a pre-defined collecting profile
-	Include       set.StringSet // types of data to collect
-	Exclude       set.StringSet // types of data not to collect
-	MetricsFilter []string      // prefix of metrics to collect"
-	Dir           string        // target directory to store collected data
-	Limit         int           // rate limit of SCP
-	PerfDuration  int           //seconds: profile time(s), default is 30s.
-	CompressScp   bool          // compress of files during collecting
-	ExitOnError   bool          // break the process and exit when an error occur
+	RawRequest    interface{}       // raw collect command or request
+	Mode          string            // the cluster is deployed with what type of tool
+	ProfileName   string            // the name of a pre-defined collecting profile
+	Include       set.StringSet     // types of data to collect
+	Exclude       set.StringSet     // types of data not to collect
+	MetricsFilter []string          // prefix of metrics to collect"
+	Dir           string            // target directory to store collected data
+	Limit         int               // rate limit of SCP
+	PerfDuration  int               //seconds: profile time(s), default is 30s.
+	CompressScp   bool              // compress of files during collecting
+	ExitOnError   bool              // break the process and exit when an error occur
+	ExtendedAttrs map[string]string // extended attributes used for manual collecting mode
 }
 
 // CollectStat is estimated size stats of data to be collected
@@ -155,6 +162,19 @@ func (m *Manager) CollectClusterInfo(
 			tlsCfg, err = kubetls.GetClusterClientTLSConfig(kubeCli, opt.Namespace, opt.Cluster, time.Duration(gOpt.APITimeout))
 			klog.Infof("get tls config from secrets success")
 		}
+	case CollectModeManual:
+		cls, err = buildTopoForManualCluster(cOpt)
+		if err != nil {
+			return "", err
+		}
+		tlsCfg, err = tlsConfig(
+			cOpt.ExtendedAttrs[AttrKeyTLSCAFile],
+			cOpt.ExtendedAttrs[AttrKeyTLSCertFile],
+			cOpt.ExtendedAttrs[AttrKeyTLSKeyFile],
+		)
+		if err != nil {
+			return "", err
+		}
 	default:
 		return "", fmt.Errorf("unknown collect mode '%s'", cOpt.Mode)
 	}
@@ -169,7 +189,8 @@ func (m *Manager) CollectClusterInfo(
 	var resultDir string
 	var prompt string
 	switch cOpt.Mode {
-	case CollectModeTiUP:
+	case CollectModeTiUP,
+		CollectModeManual:
 		prompt, resultDir, err = m.prepareArgsForTiUPCluster(opt, cOpt)
 	case CollectModeK8s:
 		resultDir, err = m.prepareArgsForK8sCluster(opt, cOpt)
@@ -254,9 +275,10 @@ func (m *Manager) CollectClusterInfo(
 	}
 
 	// populate SSH credentials if needed
-	if m.mode == CollectModeTiUP && (canCollect(cOpt, CollectTypeSystem) ||
-		canCollect(cOpt, CollectTypeLog) ||
-		canCollect(cOpt, CollectTypeConfig)) {
+	if (m.mode == CollectModeTiUP || m.mode == CollectModeManual) &&
+		(canCollect(cOpt, CollectTypeSystem) ||
+			canCollect(cOpt, CollectTypeLog) ||
+			canCollect(cOpt, CollectTypeConfig)) {
 		// collect data from remote servers
 		var sshConnProps *tui.SSHConnectionProps = &tui.SSHConnectionProps{}
 		if gOpt.SSHType != executor.SSHTypeNone {
@@ -416,7 +438,9 @@ func (m *Manager) CollectClusterInfo(
 	}
 
 	// confirm before really collect
-	if m.mode == CollectModeTiUP {
+	switch m.mode {
+	case CollectModeTiUP,
+		CollectModeManual:
 		fmt.Println(prompt)
 		if err := confirmStats(stats, resultDir, sensitiveTag, skipConfirm); err != nil {
 			return "", err

--- a/collector/manual.go
+++ b/collector/manual.go
@@ -1,0 +1,50 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"crypto/tls"
+	"strings"
+
+	"github.com/pingcap/diag/pkg/models"
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+)
+
+// buildTopoForManualCluster creates an abstract topo from user input
+func buildTopoForManualCluster(cOpt *CollectOptions) (*models.TiDBCluster, error) {
+	// build the abstract topology
+	cls := &models.TiDBCluster{
+		Version:    "unknown",
+		Attributes: map[string]interface{}{},
+	}
+
+	cls.Attributes[AttrKeyPDEndpoint] = strings.Split(cOpt.ExtendedAttrs[AttrKeyPDEndpoint], ",")
+	cls.Attributes[AttrKeyPromEndpoint] = strings.Split(cOpt.ExtendedAttrs[AttrKeyPromEndpoint], ",")
+
+	return cls, nil
+}
+
+// tlsConfig generates a tls.Config from certificate files
+func tlsConfig(ca, cert, key string) (*tls.Config, error) {
+	// handle non-TLS clusters
+	if cert == "" || key == "" {
+		return nil, nil
+	}
+
+	return transport.TLSInfo{
+		TrustedCAFile: ca,
+		CertFile:      cert,
+		KeyFile:       key,
+	}.ClientConfig()
+}

--- a/collector/meta.go
+++ b/collector/meta.go
@@ -126,6 +126,13 @@ func (c *MetaCollectOptions) Collect(m *Manager, topo *models.TiDBCluster) error
 	case CollectModeK8s:
 		clusterID = c.tc.GetClusterID()
 		clusterType = spec.TopoTypeTiDB
+	case CollectModeManual:
+		endpoints := topo.Attributes[AttrKeyPDEndpoint].([]string)
+		clusterID, err = getClusterIDFromPD(ctx, endpoints, c.tlsCfg)
+		if err != nil {
+			return err
+		}
+		clusterType = spec.TopoTypeTiDB
 	default:
 		// nothing
 	}
@@ -206,6 +213,15 @@ func (c *MetaCollectOptions) Collect(m *Manager, topo *models.TiDBCluster) error
 	return nil
 }
 
+func getClusterIDFromPD(ctx context.Context, endpoints []string, tlsCfg *tls.Config) (string, error) {
+	pdAPI := api.NewPDClient(ctx, endpoints, 2*time.Second, tlsCfg)
+	id, err := pdAPI.GetClusterID()
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatUint(id, 10), nil
+}
+
 func getTiUPClusterID(ctx context.Context, clusterName string, tlsCfg *tls.Config) (string, error) {
 	metadata, err := spec.ClusterMetadata(clusterName)
 	if err != nil && !errors.Is(perrs.Cause(err), meta.ErrValidate) &&
@@ -218,10 +234,5 @@ func getTiUPClusterID(ctx context.Context, clusterName string, tlsCfg *tls.Confi
 		pdEndpoints = append(pdEndpoints, fmt.Sprintf("%s:%d", pd.Host, pd.ClientPort))
 	}
 
-	pdAPI := api.NewPDClient(ctx, pdEndpoints, 2*time.Second, tlsCfg)
-	id, err := pdAPI.GetClusterID()
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatUint(id, 10), nil
+	return getClusterIDFromPD(ctx, pdEndpoints, tlsCfg)
 }

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/vishvananda/netlink v0.0.0-20210530105856-14e832ae1e8f
 	go.etcd.io/etcd/api/v3 v3.5.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.2
 	go.etcd.io/etcd/client/v3 v3.5.2
 	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add support to dump metrics from a manual deployed TiDB cluster (DM not supported)

### What is changed and how it works?
Arguments `--name`, `--pd` and `--prometheus` are required:
 - `--name`: name of the cluster, could be any string
 - `--pd`: `<IP>:<port>` endpoint of a valid PD (do not include `http://`/`https://` prefix)
 - `--prometheus`: endpoint of a valid Prometheus

For TLS enabled clusters, `--ca-file`, `--cert-file` and `--key-file` are also needed to provide client certificates to request PD API.

Example usage:
```
diag util metricdump --name ttt0 \
  --pd="172.16.5.137:2379,172.16.5.208:2379,172.16.5.220:2379" \
  --prometheus="172.16.4.128:9090" \
  --ca-file ~/.tiup/storage/cluster/clusters/ttt/tls/ca.crt \
  --cert-file ~/.tiup/storage/cluster/clusters/ttt/tls/client.crt \
  --key-file ~/.tiup/storage/cluster/clusters/ttt/tls/client.pem
```

Note that estimated metrics data size would be 0 at this time, as we don't support topology of manual deployed clusters at present.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
