### PR TITLE
config: add plan_replayer profile

### DIFF
--- a/configs/profiles/tidb-plan-replayer.toml
+++ b/configs/profiles/tidb-plan-replayer.toml
@@ -1,0 +1,20 @@
+name = "tidb-plan-replayer"
+version = "0.0.1"
+maintainers = [
+    "pingcap"
+]
+
+# list of data types to collect
+collectors = [
+    "log",
+    "config",
+    "db_vars",
+    "sql_bind",
+    "statistics",
+    "explain"
+]
+
+# list of component roles to collect
+roles = [
+    "tidb"
+]


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

add plan_replayer profile


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

manually tested it like following

./diag collect op-test --profile=/root/gaosong/diag/configs/profiles/tidb-plan-replayer.toml  --explain-sql=/root/gaosong/diag/bin/test.sql