### PR TITLE
k8s/api: mitigate a path traversal bug

### DIFF
--- a/k8s/server/collectors.go
+++ b/k8s/server/collectors.go
@@ -346,6 +346,12 @@ func getCollectLogs(c *gin.Context) {
 // operateCollectJob implements POST /collectors/:id
 func operateCollectJob(c *gin.Context) {
 	id := c.Param("id")
+	// check if the input ID is valid
+	if _, err := base52.Decode(id); id != "" && err != nil {
+		msg := fmt.Sprintf("invalid ID: %s", err)
+		sendErrMsg(c, http.StatusBadRequest, msg)
+		return
+	}
 
 	// parse argument from POST body
 	var req types.OperateJobRequest


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
A path traversal bug presents in the re-collect API. We use the ID to build file path for collected data, but if the input `id` is a relative path like `./../../../../etc/passwd` it could access those files outside the diag directory.

### What is changed and how it works?
The ID is a base52 encoded timestamp, so just try to decode it and refuses any input that is not a valid base52 encoded timestamp.

