### PR TITLE
support dumping metrics by instance

### DIFF
--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -503,8 +503,7 @@ func collectMetric(
 		block = minQueryRange
 	}
 
-	outName := fmt.Sprintf("%s-%s-%s%s", mtc, beginTime.Format(time.RFC3339), endTime.Format(time.RFC3339), nameSuffix)
-	l.Debugf("Dumping metric %s...", outName)
+	l.Debugf("Dumping metric %s-%s-%s%s...", mtc, beginTime.Format(time.RFC3339), endTime.Format(time.RFC3339), nameSuffix)
 	for queryEnd := endTime; queryEnd.After(beginTime); queryEnd = queryEnd.Add(time.Duration(-block) * time.Second) {
 		querySec := block
 		queryBegin := queryEnd.Add(time.Duration(-block) * time.Second)
@@ -539,7 +538,7 @@ func collectMetric(
 				dst, err := os.Create(
 					filepath.Join(
 						resultDir, subdirMonitor, subdirMetrics, strings.ReplaceAll(promAddr, ":", "-"),
-						fmt.Sprintf("%s.json", outName),
+						fmt.Sprintf("%s-%s-%s%s.json", mtc, queryBegin.Format(time.RFC3339), queryEnd.Format(time.RFC3339), nameSuffix),
 					),
 				)
 				if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For a large cluster, `getSeriesNum` may always fail due to quota limit. As a result, significant metrics like `tidb_tikvclient_request_seconds` and `tikv_grpc_msg_duration_seconds` are often missing, which blocks troubleshooting. 

### What is changed and how it works?

With this PR, if `getSeriesNum` failed, diag will fallback to by-instance dump mode, which get instance list first and call `collectMetric` by instance. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [ ] Unit test
 - [ ] Integration test
 - [x] Manual test (add detailed scripts or steps below)
 - [ ] No code

Code changes

 - [ ] Has exported function/method change
 - [ ] Has exported variable/fields change
 - [ ] Has interface methods change
 - [ ] Has persistent data change

Side effects

 - [x] Possible performance regression
 - [ ] Increased code complexity
 - [ ] Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

