### PR TITLE
collector: write non-progress logs to file

### DIFF
--- a/collector/collect.go
+++ b/collector/collect.go
@@ -126,7 +126,6 @@ type CollectOptions struct {
 	ExitOnError     bool              // break the process and exit when an error occur
 	ExtendedAttrs   map[string]string // extended attributes used for manual collecting mode
 	ExplainSQLPath  string            // File path for explain sql
-	LogFile         string            // File name for the log
 	ExplainSqls     []string          // explain sqls
 	CurrDB          string
 	Header          []string

--- a/collector/collect.go
+++ b/collector/collect.go
@@ -126,6 +126,7 @@ type CollectOptions struct {
 	ExitOnError     bool              // break the process and exit when an error occur
 	ExtendedAttrs   map[string]string // extended attributes used for manual collecting mode
 	ExplainSQLPath  string            // File path for explain sql
+	LogFile         string            // File name for the log
 	ExplainSqls     []string          // explain sqls
 	CurrDB          string
 	Header          []string
@@ -529,11 +530,15 @@ func (m *Manager) CollectClusterInfo(
 
 	m.collectLock(resultDir)
 
+	logFile := initLogFile(filepath.Join(resultDir, "diag.log"), m.logger)
+	defer logFile.Close()
+
 	defer logger.OutputAuditLogToFileIfEnabled(resultDir, "diag_audit.log")
 
 	// run collectors
 	collectErrs := make(map[string]error)
 	for _, c := range collectors {
+		fmt.Printf("Collecting %s...\n", c.Desc())
 		m.logger.Infof("Collecting %s...\n", c.Desc())
 		if err := c.Collect(m, cls); err != nil {
 			if cOpt.ExitOnError {
@@ -563,7 +568,8 @@ func (m *Manager) CollectClusterInfo(
 	if m.logger.GetDisplayMode() == logprinter.DisplayModeDefault {
 		dir = color.CyanString(resultDir)
 	}
-	m.logger.Infof("Collected data are stored in %s\n", dir)
+	fmt.Printf("Collected data and log are stored in %s\n", dir)
+	m.logger.Infof("Collected data and log are stored in %s\n", dir)
 	return resultDir, nil
 }
 

--- a/collector/diaglog.go
+++ b/collector/diaglog.go
@@ -1,0 +1,32 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+
+	logprinter "github.com/pingcap/tiup/pkg/logger/printer"
+)
+
+func initLogFile(fileName string, logger *logprinter.Logger) *os.File {
+	// Create a new file with the given name
+	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	logger.SetStdout(file)
+	logger.SetStderr(file)
+	return file
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Diag! Please read Diag's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/contributors/README.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
All non-progress logs are printed to the diag.log file

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
The following log has basically remained unchanged：
 ```
Collecting metadata of the cluster...
Collecting alert lists from Prometheus node...
Collecting metrics from Prometheus node...
+ Dumping metrics
  - Query server tiup-peer:9090 ... Done
Collected data and log are stored in /root/prom-2k
 ```
 All non-progress logs are printed to the diag.log file

 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

