### PR TITLE
ci: replace deprecated PingCAP domains

### DIFF
--- a/ci/release_diag_binary_and_image.groovy
+++ b/ci/release_diag_binary_and_image.groovy
@@ -198,9 +198,9 @@ def upload_chart(chartPrefixName) {
 	"""
 
 	echo "	merge index.yaml"
-	sh "curl http://charts.pingcap.com/index.yaml -o index.yaml"
+	sh "curl https://charts.pingcap.com/index.yaml -o index.yaml"
 	sh "cat index.yaml"	
-	sh "./helm repo index . --url http://charts.pingcap.com/ --merge index.yaml"
+	sh "./helm repo index . --url https://charts.pingcap.com/ --merge index.yaml"
 	sh "cat index.yaml"	
 
 	echo "	download Qinui upload tool"

--- a/ci/release_diag_binary_and_image.groovy
+++ b/ci/release_diag_binary_and_image.groovy
@@ -198,15 +198,15 @@ def upload_chart(chartPrefixName) {
 	"""
 
 	echo "	merge index.yaml"
-	sh "curl http://charts.pingcap.org/index.yaml -o index.yaml"
+	sh "curl http://charts.pingcap.com/index.yaml -o index.yaml"
 	sh "cat index.yaml"	
-	sh "./helm repo index . --url http://charts.pingcap.org/ --merge index.yaml"	
+	sh "./helm repo index . --url http://charts.pingcap.com/ --merge index.yaml"
 	sh "cat index.yaml"	
 
 	echo "	download Qinui upload tool"
 	sh """
 		curl https://raw.githubusercontent.com/pingcap/docs-cn/a4db3fc5171ed8e4e705fb34552126a302d29c94/scripts/upload.py -o upload.py
-		sed -i 's%https://download.pingcap.org%https://charts.pingcap.org%g' upload.py
+		sed -i 's%https://download.pingcap.com%https://charts.pingcap.com%g' upload.py
 		sed -i 's/python3/python/g' upload.py
 		chmod +x upload.py
 	"""


### PR DESCRIPTION
## Summary
- replace deprecated PingCAP download/charts domain references in the diag release pipeline
- keep existing paths and protocols unchanged

## Validation
- `git diff --check`
- verified no remaining old-domain matches in the touched file